### PR TITLE
fix import to pyicloud_ipd

### DIFF
--- a/pyicloud/cmdline.py
+++ b/pyicloud/cmdline.py
@@ -11,7 +11,7 @@ import sys
 
 from click import confirm
 
-import pyicloud
+import pyicloud_ipd
 from . import utils
 
 


### PR DESCRIPTION
When trying to use that new pyicloud it throw an error 
```
/ $ icloud
Traceback (most recent call last):
  File "/usr/bin/icloud", line 7, in <module>
    from pyicloud_ipd.cmdline import main
  File "/usr/lib/python2.7/site-packages/pyicloud_ipd/cmdline.py", line 14, in <module>
    import pyicloud
ImportError: No module named pyicloud
```

to fix this i needed to change in the file '/usr/lib/python2.7/site-packages/pyicloud_ipd/cmdline.py'

from
```
import pyicloud
```
to
```
import pyicloud_ipd
```